### PR TITLE
remove signing target from build rules

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,6 @@
    apply plugin: 'maven'
    apply plugin: 'idea'
    apply plugin: 'eclipse'
-   apply plugin: 'signing'
 
   group = 'uk.ac.ebi.ena.sequence'
 
@@ -54,11 +53,6 @@
     archives jar
     archives javadocJar
     archives sourcesJar
- }
-
- signing 
- {
-    sign configurations.archives
  }
 
   task wrapper(type: Wrapper) { gradleVersion = '1.12' 


### PR DESCRIPTION
Hi,

with respect to #4 one more change was necessary to allow building for me: removing the signing functionality from `build.gradle`. Otherwise I would have seen:

```
* What went wrong:
Execution failed for task ':embl-api-core:signArchives'.
> Cannot perform signing task ':embl-api-core:signArchives' because it has no configured signatory
```