### PR TITLE
Update FastaFileReader.java

### DIFF
--- a/embl-api-ff/src/main/java/uk/ac/ebi/embl/fasta/reader/FastaFileReader.java
+++ b/embl-api-ff/src/main/java/uk/ac/ebi/embl/fasta/reader/FastaFileReader.java
@@ -47,12 +47,13 @@ public class FastaFileReader extends FlatFileEntryReader
 		entry = (new EntryFactory()).createEntry();
 		entry.setSequence((new SequenceFactory()).createSequence());
 		entry.getSequence().setTopology(Topology.LINEAR);
-		String object_name = readObjectName(lineReader);
-		if (object_name != null)
-		{
-			entry.setSubmitterAccession(object_name);
-			isEntry=true;
-		}
+	        String object_name = readObjectName(lineReader);
+	        if(object_name != null) {
+		      entry.setSubmitterAccession(object_name);
+		      Text header = new Text(lineReader.getCurrentRawLine());
+		      entry.setComment(header);
+		      isEntry = true;
+    		}
 		if(!lineReader.isNextTag())
 		{
 			lineReader.readLine();


### PR DESCRIPTION
I am currently using the EMBL and FASTA parser not only as validator but also for integration into bioinformatic pipelines. 

When parsing a fasta file I noticed that the header is lost (or I missed something) and only the first group is captured using the regex. Here is an idea of keeping the header of the fasta file as for example a comment such that this information is not lost.