### PR TITLE
issue#45: make NCR files not requiring AC line present

### DIFF
--- a/.project
+++ b/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>sequencetools</name>
+	<comment>Project sequencetools created by Buildship.</comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.buildship.core.gradleprojectbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.buildship.core.gradleprojectnature</nature>
+	</natures>
+</projectDescription>

--- a/embl-api-ff/src/main/java/uk/ac/ebi/embl/flatfile/reader/embl/EmblEntryReader.java
+++ b/embl-api-ff/src/main/java/uk/ac/ebi/embl/flatfile/reader/embl/EmblEntryReader.java
@@ -33,7 +33,7 @@ EmblEntryReader extends EntryReader
 
   // private static List<String> AT_LEAST_ONCE_BLOCKS = Arrays.asList( EmblTag.RN_TAG, EmblTag.RT_TAG, EmblTag.RL_TAG );
 
-    private static List<String> EXACTLY_ONCE_BLOCKS  = Arrays.asList( EmblTag.ID_TAG, EmblTag.AC_TAG, EmblTag.DE_TAG );
+    private List<String> EXACTLY_ONCE_BLOCKS  = Arrays.asList( EmblTag.ID_TAG, EmblTag.AC_TAG, EmblTag.DE_TAG );
 
     private static List<String> NONE_OR_ONCE_BLOCKS  = Arrays.asList( EmblTag.ST_STAR_TAG, EmblTag.DT_TAG, EmblTag.KW_TAG, EmblTag.PR_TAG, EmblTag.SQ_TAG, EmblTag.AH_TAG, EmblTag.CO_TAG, EmblTag.MASTER_CON_TAG, EmblTag.MASTER_WGS_TAG,
 			EmblTag.MASTER_TPA_TAG);
@@ -186,6 +186,7 @@ EmblEntryReader extends EntryReader
 			addBlockReader(new RTReader(lineReader));
 		} else if( format.equals( Format.NCR_FORMAT ) )
         {
+		   EXACTLY_ONCE_BLOCKS  = Arrays.asList( EmblTag.ID_TAG, EmblTag.DE_TAG );
 			addBlockReader(new IDReader(lineReader,true));
 			addBlockReader(new PAReader(lineReader));
 			addBlockReader(new ACReader(lineReader));


### PR DESCRIPTION
Remove the constraint of having a exactly on AC line in Non-coding entries