### PR TITLE
read coverage numbers from SQ line and add to Entry

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ archivesBaseName = 'sequencetools'
 group = 'uk.ac.ebi.ena.sequence'
 
 
-ext.version_base = '2.6.0'
+ext.version_base = '2.6.1'
 
 version = version_base
 tasks.withType(Javadoc).all { enabled = false }

--- a/src/main/java/uk/ac/ebi/embl/api/entry/Entry.java
+++ b/src/main/java/uk/ac/ebi/embl/api/entry/Entry.java
@@ -16,10 +16,9 @@
 package uk.ac.ebi.embl.api.entry;
 
 import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Date;
-import java.util.List;
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.apache.commons.lang.builder.CompareToBuilder;
 import org.apache.commons.lang.builder.EqualsBuilder;
@@ -135,6 +134,10 @@ public class Entry implements HasOrigin, Serializable, Comparable<Entry> {
 	private boolean isNonExpandedCON=false;
 	private int sequenceCount;
 	private int entryType;
+	/**
+	 * get sequence coverage numbers with keys BP, A, C, G, T or other
+	 */
+	private Map<String, Long> sequenceCoverage;
 
 	public Entry() {
 		this.secondaryAccessions = new ArrayList<>();
@@ -154,6 +157,14 @@ public class Entry implements HasOrigin, Serializable, Comparable<Entry> {
 		masterScaffoldAccessions = new ArrayList<>();
 		this.deleteEntry=false;
 		this.isNonExpandedCON=false;
+		this.sequenceCoverage = Stream.of(
+				new AbstractMap.SimpleEntry<>("BP", 0l),
+				new AbstractMap.SimpleEntry<>("A", 0l),
+				new AbstractMap.SimpleEntry<>("C", 0l),
+				new AbstractMap.SimpleEntry<>("G", 0l),
+				new AbstractMap.SimpleEntry<>("T", 0l),
+				new AbstractMap.SimpleEntry<>("other", 0l))
+				.collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
     }
 		
@@ -764,5 +775,13 @@ public class Entry implements HasOrigin, Serializable, Comparable<Entry> {
 
 	public void setEntryType(int entryType) {
 		this.entryType = entryType;
+	}
+
+	public Map<String, Long> getSequenceCoverage() {
+		return sequenceCoverage;
+	}
+
+	public void setSequenceCoverage(Map<String, Long> sequenceCoverage) {
+		this.sequenceCoverage = sequenceCoverage;
 	}
 }

--- a/src/main/java/uk/ac/ebi/embl/flatfile/reader/embl/SQReader.java
+++ b/src/main/java/uk/ac/ebi/embl/flatfile/reader/embl/SQReader.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright 2012 EMBL-EBI, Hinxton outstation
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,25 +15,43 @@
  ******************************************************************************/
 package uk.ac.ebi.embl.flatfile.reader.embl;
 
-import uk.ac.ebi.embl.flatfile.reader.SingleLineBlockReader;
+import org.apache.commons.lang3.StringUtils;
 import uk.ac.ebi.embl.flatfile.EmblTag;
 import uk.ac.ebi.embl.flatfile.reader.LineReader;
+import uk.ac.ebi.embl.flatfile.reader.SingleLineBlockReader;
 
-/** Reader for the SQ line.
+import java.util.Arrays;
+
+/**
+ * Reader for the SQ line. Capture coverage values
  */
 public class SQReader extends SingleLineBlockReader {
 
-	public SQReader(LineReader lineReader) {
-		super(lineReader); //, ConcatenateType.CONCATENATE_NOSPACE);
-	}
+    public SQReader(LineReader lineReader) {
+        super(lineReader); //, ConcatenateType.CONCATENATE_NOSPACE);
+    }
 
-	@Override
-	public String getTag() {
-		return EmblTag.SQ_TAG;
-	}
-		
-	@Override
-	protected void read(String block) {
-		return;
-	}
+    @Override
+    public String getTag() {
+        return EmblTag.SQ_TAG;
+    }
+
+    @Override
+    protected void read(String block) {
+        // SQ   Sequence 315242 BP; 87432 A; 72431 C; 71123 G; 84256 T; 0 other;
+        if (StringUtils.isNotBlank(block)) {
+            try {
+                Arrays.stream(StringUtils.stripAll(
+                        StringUtils.split(
+                                StringUtils.stripStart(block, "SQ   Sequence"), ";")))
+                        .forEach(s -> {
+                            final String[] split = StringUtils.split(s, " ");
+                            entry.getSequenceCoverage().put(split[1], Long.valueOf(split[0]));
+                        });
+            } catch (Exception e) {
+                // fail silently
+            }
+        }
+        return;
+    }
 }

--- a/src/test/java/uk/ac/ebi/embl/flatfile/reader/embl/SQReaderTest.java
+++ b/src/test/java/uk/ac/ebi/embl/flatfile/reader/embl/SQReaderTest.java
@@ -37,4 +37,19 @@ public class SQReaderTest extends EmblReaderTest {
 		ValidationResult result = (new SQReader(lineReader)).read(entry);
 		assertEquals(0, result.count(Severity.ERROR));
 	}
+
+	public void testRead_Coverage() throws IOException {
+		initLineReader(
+				"SQ   Sequence 315242 BP; 87432 A; 72431 C; 71123 G; 84256 T; 0 other;"
+		);
+		ValidationResult result = (new SQReader(lineReader)).read(entry);
+		assertEquals(0, result.count(Severity.ERROR));
+		assertEquals(entry.getSequenceCoverage().get("BP").longValue(), 315242l);
+		assertEquals(entry.getSequenceCoverage().get("A").longValue(), 87432l);
+		assertEquals(entry.getSequenceCoverage().get("C").longValue(), 72431l);
+		assertEquals(entry.getSequenceCoverage().get("G").longValue(), 71123l);
+		assertEquals(entry.getSequenceCoverage().get("T").longValue(), 84256l);
+		assertEquals(entry.getSequenceCoverage().get("other").longValue(), 0l);
+	}
+
 }


### PR DESCRIPTION
ebisearch asked if embl-api had a way to get coverage numbers without them having to scan the sequence