### PR TITLE
ENA-4500: Fixing taxonomy division

### DIFF
--- a/src/main/java/uk/ac/ebi/embl/api/validation/check/file/MasterEntryValidationCheck.java
+++ b/src/main/java/uk/ac/ebi/embl/api/validation/check/file/MasterEntryValidationCheck.java
@@ -89,7 +89,7 @@ public class MasterEntryValidationCheck extends FileValidationCheck
 					throw new ValidationEngineException("SubmissionOption source must be given to generate master entry");
 				sharedInfo.masterEntry = getMasterEntry(getAnalysisType(), getOptions().assemblyInfoEntry.get(), getOptions().source.get());
 			}
-
+			
 			if(Context.transcriptome == options.context.get() && sharedInfo.masterEntry != null) {
 				addTranscriptomeInfo(sharedInfo.masterEntry);
 			}
@@ -158,9 +158,6 @@ public class MasterEntryValidationCheck extends FileValidationCheck
 			masterEntry.removeReferences();
 			masterEntry.addReference(new ReferenceUtils().getSubmitterReferenceFromManifest(options.assemblyInfoEntry.get().getAuthors(),
 					options.assemblyInfoEntry.get().getAddress(), options.assemblyInfoEntry.get().getDate(), options.assemblyInfoEntry.get().getSubmissionAccountId()));
-		}
-		if(masterEntry.getDivision() == null && source.getTaxon() != null ) {
-			masterEntry.setDivision(source.getTaxon().getDivision());
 		}
 		return masterEntry;
 	}

--- a/src/main/java/uk/ac/ebi/embl/api/validation/dao/EraproDAOUtilsImpl.java
+++ b/src/main/java/uk/ac/ebi/embl/api/validation/dao/EraproDAOUtilsImpl.java
@@ -573,9 +573,6 @@ public class EraproDAOUtilsImpl implements EraproDAOUtils
 		}
 
 		sourceFeature = new MasterSourceFeatureUtils().constructSourceFeature(getSampleAttributes(sampleId), taxonHelper, sampleInfo);
-		if(sourceFeature.getTaxon() != null ) {
-			masterEntry.setDivision(sourceFeature.getTaxon().getDivision());
-		}
 		masterEntry.addFeature(sourceFeature);
 		String description = SequenceEntryUtils.generateMasterEntryDescription(sourceFeature, analysisType, isTpa);
 		masterEntry.setDescription(new Text(description));

--- a/src/main/java/uk/ac/ebi/embl/api/validation/fixer/entry/DivisionFix.java
+++ b/src/main/java/uk/ac/ebi/embl/api/validation/fixer/entry/DivisionFix.java
@@ -1,0 +1,96 @@
+/*******************************************************************************
+ * Copyright 2012 EMBL-EBI, Hinxton outstation
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+package uk.ac.ebi.embl.api.validation.fixer.entry;
+
+import org.apache.commons.lang.StringUtils;
+import uk.ac.ebi.embl.api.entry.Entry;
+import uk.ac.ebi.embl.api.entry.feature.SourceFeature;
+import uk.ac.ebi.embl.api.entry.qualifier.Qualifier;
+import uk.ac.ebi.embl.api.validation.*;
+import uk.ac.ebi.embl.api.validation.annotation.Description;
+import uk.ac.ebi.embl.api.validation.annotation.ExcludeScope;
+import uk.ac.ebi.embl.api.validation.check.entry.EntryValidationCheck;
+import uk.ac.ebi.ena.taxonomy.client.TaxonomyClient;
+import uk.ac.ebi.ena.taxonomy.client.TaxonomyClientImpl;
+import uk.ac.ebi.ena.taxonomy.taxon.Taxon;
+
+import java.util.List;
+
+@Description("Division has been set to \"{0}\"" +
+		"No division found. Division has been set to \"{0}\"")
+@ExcludeScope(validationScope = {ValidationScope.ASSEMBLY_MASTER, ValidationScope.NCBI_MASTER})
+public class DivisionFix extends EntryValidationCheck
+{
+
+	private final static String DIVISION_FIX_ID = "DivisionFix_1";
+	private final static String DIVISION_NOT_FOUND_ID = "DivisionFix_2";
+	
+
+	public DivisionFix()
+	{
+	}
+
+	public ValidationResult check(Entry entry) throws ValidationEngineException {
+
+		result=new ValidationResult();
+		
+		if (entry == null || entry.getPrimarySourceFeature() == null) {
+			return result;
+		}
+		
+		if(empty(entry.getDivision())) {
+			
+			try {
+				SourceFeature primarySF = entry.getPrimarySourceFeature();
+				TaxonomyClient taxonomyClient = new TaxonomyClientImpl();
+
+				// Get division using transgenic/pseduo
+				String division = (primarySF.isTransgenic()) ? "TGN" : (null != primarySF.getSingleQualifier(Qualifier.ENVIRONMENTAL_SAMPLE_QUALIFIER_NAME)) ? "ENV" : "";
+
+				// Get division using tax_id
+				if (empty(division) && primarySF.getTaxId() != null) {
+					division = taxonomyClient.getTaxonByTaxid(Long.valueOf(primarySF.getTaxId())).getDivision();
+				}
+
+				// Get division using Scientific name
+				if (empty(division) && primarySF.getScientificName() != null) {
+					List<Taxon> taxonList;
+					if (!(taxonList = taxonomyClient.getTaxonByScientificName(primarySF.getScientificName())).isEmpty()) {
+						division = taxonList.get(0).getDivision();
+					}
+				}
+				
+				// Set division if found one.
+				if (!empty(division)) {
+					entry.setDivision(division);
+					reportMessage(Severity.FIX, entry.getOrigin(), DIVISION_FIX_ID, division);
+				} else {
+					// If division is not found then division will be updated as XXX.
+					entry.setDivision("XXX");
+					reportMessage(Severity.FIX, entry.getOrigin(), DIVISION_NOT_FOUND_ID, "XXX");
+				}
+			} catch (Exception e) {
+				throw new ValidationEngineException(e.getMessage(), e);
+			}
+		}
+		return result;
+	}
+
+	public static boolean empty(String input){
+		return StringUtils.isEmpty(input);
+	}
+
+}

--- a/src/main/java/uk/ac/ebi/embl/api/validation/plan/ValidationUnit.java
+++ b/src/main/java/uk/ac/ebi/embl/api/validation/plan/ValidationUnit.java
@@ -162,6 +162,7 @@ public enum ValidationUnit
 	        		HoldDateFix.class,//include for all
 					ReferencePositionFix.class,//include for all
 					DataclassFix.class,//include for all
+					DivisionFix.class,
 					TPA_dataclass_Fix.class,//exclude for master
 					AccessionFix.class,//exclude for master
 					NonAsciiCharacterFix.class,//include for all

--- a/src/main/java/uk/ac/ebi/embl/flatfile/reader/embl/IDReader.java
+++ b/src/main/java/uk/ac/ebi/embl/flatfile/reader/embl/IDReader.java
@@ -84,7 +84,7 @@ public class IDReader extends SingleLineBlockReader {
 	protected void read(String block) {
 		entry.setOrigin(getOrigin());
 		FlatFileMatcher matcher = new FlatFileMatcher(this, PATTERN);
-		if(!matcher.match(block)) {
+		if (!matcher.match(block)) {
 			error("FF.1", getTag());
 			return;
 		}
@@ -92,12 +92,11 @@ public class IDReader extends SingleLineBlockReader {
 			if (preserveCase) {
 				entry.setPrimaryAccession(matcher.getString(GROUP_PRIMARY_ACCESSION));
 				entry.getSequence().setAccession(matcher.getString(GROUP_PRIMARY_ACCESSION));
-			}
-			else {
+			} else {
 				entry.setPrimaryAccession(matcher.getUpperString(GROUP_PRIMARY_ACCESSION));
 				entry.getSequence().setAccession(matcher.getUpperString(GROUP_PRIMARY_ACCESSION));
 			}
-					
+
 		}
 		if (matcher.isValueXXX(GROUP_SEQUENCE_VERSION) && matcher.getInteger(GROUP_SEQUENCE_VERSION) >= 1) {
 			entry.getSequence().setVersion(matcher.getInteger(GROUP_SEQUENCE_VERSION));
@@ -113,13 +112,10 @@ public class IDReader extends SingleLineBlockReader {
 		}
 		Long sequenceLength = matcher.getLong(GROUP_SEQUENCE_LENGTH);
 		if (sequenceLength != null) {
-			entry.setIdLineSequenceLength(matcher.getLong(GROUP_SEQUENCE_LENGTH));			
+			entry.setIdLineSequenceLength(matcher.getLong(GROUP_SEQUENCE_LENGTH));
 		}
 		if (matcher.isValueXXX(GROUP_DATACLASS)) {
 			entry.setDataClass(matcher.getUpperString(GROUP_DATACLASS));
-			}
-		if (matcher.isValueXXX(GROUP_DIVISION)) {
-			entry.setDivision(matcher.getUpperString(GROUP_DIVISION));
 		}
 	}
 	

--- a/src/main/resources/uk/ac/ebi/embl/api/validation/FixerMessages.properties
+++ b/src/main/resources/uk/ac/ebi/embl/api/validation/FixerMessages.properties
@@ -116,3 +116,6 @@ fixNoStartCodonMake5Partial=The protein translation of the protein coding featur
 fixCodonStartNotOneMake5Partial=5' partial applied to the location as the protein coding feature with start codon {0} must be 5' partial.
 
 AsciiCharacterFix_1=Non-ascii characters fixed from \"{0}\" to \"{1}\".
+
+DivisionFix_1= Division has been set to \"{0}\" 
+DivisionFix_2= No division found. Division has been set to \"{0}\"

--- a/src/test/java/uk/ac/ebi/embl/api/validation/fixer/entry/DivisionFixTest.java
+++ b/src/test/java/uk/ac/ebi/embl/api/validation/fixer/entry/DivisionFixTest.java
@@ -1,0 +1,141 @@
+/*******************************************************************************
+ * Copyright 2012 EMBL-EBI, Hinxton outstation
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+package uk.ac.ebi.embl.api.validation.fixer.entry;
+
+import org.json.JSONObject;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import uk.ac.ebi.embl.api.entry.Entry;
+import uk.ac.ebi.embl.api.entry.EntryFactory;
+import uk.ac.ebi.embl.api.entry.Text;
+import uk.ac.ebi.embl.api.entry.feature.FeatureFactory;
+import uk.ac.ebi.embl.api.entry.feature.SourceFeature;
+import uk.ac.ebi.embl.api.storage.DataRow;
+import uk.ac.ebi.embl.api.validation.*;
+import uk.ac.ebi.ena.taxonomy.taxon.Taxon;
+import uk.ac.ebi.ena.taxonomy.taxon.TaxonFactory;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class DivisionFixTest
+{
+
+	private Entry entry;
+	private DivisionFix check;
+	public EntryFactory entryFactory;
+	public FeatureFactory featureFactory;
+	public SourceFeature sourceFeature;
+	public Taxon taxon;
+
+	@Before
+	public void setUp()
+	{
+		ValidationMessageManager.addBundle(ValidationMessageManager.STANDARD_FIXER_BUNDLE);
+
+		entryFactory = new EntryFactory();
+		featureFactory = new FeatureFactory();
+		entry = entryFactory.createEntry();
+		sourceFeature = featureFactory.createSourceFeature();
+
+		TaxonFactory taxonFactory = new TaxonFactory();
+		JSONObject taxonJasonObject= new JSONObject("{"+
+				"\"taxId\": \"2759\","+
+				"\"scientificName\": \"Felis catus\","+
+				"\"commonName\": \"domestic cat\","+
+				"\"formalName\": \"true\","+
+				"\"rank\": \"superkingdom\","+
+				"\"division\": \"INV\","+
+				"\"lineage\": \"Eukaryota; Metazoa; Chordata; Craniata; Vertebrata; Euteleostomi; Mammalia;Eutheria; Laurasiatheria; Carnivora; Feliformia; Felidae; Felinae; Felis;\","+
+				"\"geneticCode\": \"1\","+
+				"\"mitochondrialGeneticCode\": \"1\","+
+				"\"plastIdGeneticCode\": \"11\""+
+				"}");
+		taxon = taxonFactory.createTaxon(taxonJasonObject);
+		
+		check = new DivisionFix();
+	}
+
+	@After
+	public void tearDown() {
+		GlobalDataSets.resetTestDataSets();
+	}
+
+	@Test
+	public void testCheck_NoEntry() throws ValidationEngineException {
+		assertTrue(check.check(null).isValid());
+	}
+
+	@Test
+	public void testCheck_NoPrimarySourceFeature() throws ValidationEngineException {
+		assertTrue(check.check(null).isValid());
+	}
+
+	@Test
+	public void testCheck_entryWithValidDivision() throws ValidationEngineException {
+		entry.setDivision("PHG");
+		assertTrue(check.check(entry).isValid());
+	}
+
+	@Test
+	public void testCheck_entryWithTransgenicFix() throws ValidationEngineException {
+		sourceFeature.setTransgenic(true);
+		entry.addFeature(sourceFeature);
+		ValidationResult result=check.check(entry);
+		assertTrue(!result.getMessages(Severity.FIX).isEmpty());
+		assertEquals(1, result.count("DivisionFix_1", Severity.FIX));
+	}
+	
+	@Test
+	public void testCheck_entryWithEnvironmentalSampleQualifierName() throws ValidationEngineException {
+		sourceFeature.setSingleQualifier("environmental_sample");
+		entry.addFeature(sourceFeature);
+		ValidationResult result=check.check(entry);
+		assertTrue(!result.getMessages(Severity.FIX).isEmpty());
+		assertEquals(1, result.count("DivisionFix_1", Severity.FIX));
+	}
+
+	@Test
+	public void testCheck_entrySourceFeatureWithTaxId() throws ValidationEngineException {
+		sourceFeature.setTaxon(taxon);
+		entry.addFeature(sourceFeature);
+		ValidationResult result=check.check(entry);
+		assertTrue(!result.getMessages(Severity.FIX).isEmpty());
+		assertEquals(1, result.count("DivisionFix_1", Severity.FIX));
+	}
+
+	@Test
+	public void testCheck_entrySourceFeatureWithScientificName() throws ValidationEngineException {
+		taxon.setTaxId(null); // Set taxId to null for getting division by ScientificName
+		sourceFeature.setTaxon(taxon);
+		entry.addFeature(sourceFeature);
+		ValidationResult result=check.check(entry);
+		assertTrue(!result.getMessages(Severity.FIX).isEmpty());
+		assertEquals(1, result.count("DivisionFix_1", Severity.FIX));
+	}
+
+	@Test
+	public void testCheck_entrySourceFeatureWithInvalidTaxIdAndScientificName() throws ValidationEngineException {
+		taxon.setTaxId(null); 
+		taxon.setScientificName("INVALID NAME");
+		sourceFeature.setTaxon(taxon);
+		entry.addFeature(sourceFeature);
+		ValidationResult result=check.check(entry);
+		assertTrue(!result.getMessages(Severity.FIX).isEmpty());
+		assertEquals(1, result.count("DivisionFix_2", Severity.FIX)); // Set division to XXX
+	}
+}


### PR DESCRIPTION
Removed logic to set division from:

- MasterEntryValidationCheck.java
- EraproDAOUtilsImpl.java
- IdReader.java

Added new fix to set division in:

- Division.java