### PR TITLE
master comment generation code moved to sequencetools

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ archivesBaseName = 'sequencetools'
 group = 'uk.ac.ebi.ena.sequence'
 
 
-ext.version_base = '2.10.5'
+ext.version_base = '2.10.6'
 
 
 version = version_base

--- a/src/main/java/uk/ac/ebi/embl/api/service/MasterEntryService.java
+++ b/src/main/java/uk/ac/ebi/embl/api/service/MasterEntryService.java
@@ -79,6 +79,19 @@ public class MasterEntryService {
             masterEntry.setComment(new Text(comment));
         }
 
+        if (Context.transcriptome == options.context.get() && masterEntry != null) {
+            try {
+                String ccLine = utils.getCommentsToTranscriptomeMaster(options.analysisId.get());
+                if ( StringUtils.isNotBlank(masterEntry.getComment().getText())) {
+                    ccLine += "\n" + masterEntry.getComment().getText();
+                }
+                masterEntry.setComment(new Text(ccLine));
+            } catch (SQLException throwables) {
+                throw new ValidationEngineException(throwables);
+            }
+
+        }
+
         return masterEntry;
     }
 

--- a/src/main/java/uk/ac/ebi/embl/api/validation/dao/EraproDAOUtils.java
+++ b/src/main/java/uk/ac/ebi/embl/api/validation/dao/EraproDAOUtils.java
@@ -25,6 +25,7 @@ public interface EraproDAOUtils
     boolean isProjectValid(String text) throws SQLException;
 	boolean isIgnoreErrors(String submissionAccountId, String context, String name) throws SQLException;
 	Analysis getAnalysis(String analysisId) throws SQLException;
+	String getCommentsToTranscriptomeMaster(String analysisId) throws SQLException;
 
 	class AssemblySubmissionInfo
 	{

--- a/src/main/java/uk/ac/ebi/embl/api/validation/dao/EraproDAOUtilsImpl.java
+++ b/src/main/java/uk/ac/ebi/embl/api/validation/dao/EraproDAOUtilsImpl.java
@@ -581,6 +581,24 @@ public class EraproDAOUtilsImpl implements EraproDAOUtils
 		return masterEntry;
 	}
 
+	public String getCommentsToTranscriptomeMaster(String analysisId) throws SQLException {
+		String analysisQuery = "select " +
+				"XMLSERIALIZE(CONTENT XMLQuery('/ANALYSIS_SET/ANALYSIS/ANALYSIS_TYPE/TRANSCRIPTOME_ASSEMBLY/NAME/text()' PASSING analysis_xml RETURNING CONTENT)) name, " +
+				"XMLSERIALIZE(CONTENT XMLQuery('/ANALYSIS_SET/ANALYSIS/ANALYSIS_TYPE/TRANSCRIPTOME_ASSEMBLY/PLATFORM/text()' PASSING analysis_xml RETURNING CONTENT)) platform, " +
+				"XMLSERIALIZE(CONTENT XMLQuery('/ANALYSIS_SET/ANALYSIS/ANALYSIS_TYPE/TRANSCRIPTOME_ASSEMBLY/PROGRAM/text()' PASSING analysis_xml RETURNING CONTENT)) program, " +
+				"from analysis " +
+				"where analysis_id=?";
+		ResultSet rs;
+		try (PreparedStatement stmt = connection.prepareStatement(analysisQuery)) {
+			stmt.setString(1, analysisId);
+			rs = stmt.executeQuery();
+			if (rs.next()) {
+				return  "Assembly Name: " + rs.getString("name") + "\nAssembly Method: " + rs.getString("platform") + "\nSequencing Technology: " + rs.getString("program");
+			}
+		}
+		return null;
+	}
+
 
 	private SampleInfo getSampleInfo(String sampleId) throws SQLException {
 
@@ -650,5 +668,5 @@ public class EraproDAOUtilsImpl implements EraproDAOUtils
 			}
 		}
 	}
-   
+
 }


### PR DESCRIPTION
-  master comment generation code moved to sequencetools
- we were making 3 db calls to generate this in ena-processing
- sequencetools in the correct place to do this, as of now for safety it is in separate method(don't want to break anything), later when we migrate to webin-era-service it cane be merged ith matser query