### PR TITLE
ENA-5448

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ archivesBaseName = 'sequencetools'
 group = 'uk.ac.ebi.ena.sequence'
 
 
-ext.version_base = '2.17.0'
+ext.version_base = '2.17.1'
 
 
 version = version_base
@@ -99,7 +99,7 @@ dependencies
 
             compile group: 'org.mapdb', name: 'mapdb', version: '3.0.7'
 
-            compile( 'uk.ac.ebi.ena.webin-cli:webin-cli-validator:1.7.0' )
+            compile( 'uk.ac.ebi.ena.webin-cli:webin-cli-validator:1.7.1' )
             compile(group: 'uk.ac.ebi.ena.taxonomy', name: 'webin-taxonomy-sdk', version: '1.0.2')
 
             testImplementation 'org.mockito:mockito-core:3.12.4'

--- a/src/main/java/uk/ac/ebi/embl/api/validation/submission/SubmissionOptions.java
+++ b/src/main/java/uk/ac/ebi/embl/api/validation/submission/SubmissionOptions.java
@@ -43,7 +43,6 @@ public class SubmissionOptions
 
 	private EmblEntryValidationPlanProperty property =null;
 
-	public  boolean webinCliTestMode = false;
 	public  boolean isDevMode = false;
 	public  boolean isFixMode = true;
 	public  boolean isFixCds = true;

--- a/src/main/java/uk/ac/ebi/embl/api/validation/submission/SubmissionValidator.java
+++ b/src/main/java/uk/ac/ebi/embl/api/validation/submission/SubmissionValidator.java
@@ -158,7 +158,17 @@ public class SubmissionValidator implements Validator<Manifest,ValidationRespons
             options.webinAuthToken = Optional.of(manifest.getWebinAuthToken());
             options.biosamplesWebinAuthToken = Optional.of(manifest.getWebinAuthToken());
         }
+
+        if (manifest.getWebinRestUri() != null) {
+            options.webinRestUri = Optional.of(manifest.getWebinRestUri());
+        }
+
+        if (manifest.getBiosamplesUri() != null) {
+            options.biosamplesUri = Optional.of(manifest.getBiosamplesUri());
+        }
+
         options.webinCliTestMode = manifest.getWebinCliTestMode();
+
         return options;
     }
 

--- a/src/main/java/uk/ac/ebi/embl/api/validation/submission/SubmissionValidator.java
+++ b/src/main/java/uk/ac/ebi/embl/api/validation/submission/SubmissionValidator.java
@@ -167,8 +167,6 @@ public class SubmissionValidator implements Validator<Manifest,ValidationRespons
             options.biosamplesUri = Optional.of(manifest.getBiosamplesUri());
         }
 
-        options.webinCliTestMode = manifest.getWebinCliTestMode();
-
         return options;
     }
 

--- a/src/test/java/uk/ac/ebi/embl/api/validation/submission/SubmissionValidatorTest.java
+++ b/src/test/java/uk/ac/ebi/embl/api/validation/submission/SubmissionValidatorTest.java
@@ -1,5 +1,6 @@
 package uk.ac.ebi.embl.api.validation.submission;
 
+import org.junit.Assert;
 import org.junit.Test;
 import uk.ac.ebi.embl.api.entry.feature.SourceFeature;
 import uk.ac.ebi.embl.api.entry.genomeassembly.AssemblyInfoEntry;
@@ -8,15 +9,20 @@ import uk.ac.ebi.embl.api.entry.location.LocationFactory;
 import uk.ac.ebi.embl.api.entry.location.Order;
 import uk.ac.ebi.embl.api.entry.qualifier.Qualifier;
 import uk.ac.ebi.embl.api.validation.ValidationEngineException;
+import uk.ac.ebi.ena.webin.cli.validator.api.ValidationResponse;
 import uk.ac.ebi.ena.webin.cli.validator.file.SubmissionFile;
 import uk.ac.ebi.ena.webin.cli.validator.file.SubmissionFiles;
 import uk.ac.ebi.ena.webin.cli.validator.manifest.GenomeManifest;
 import uk.ac.ebi.ena.webin.cli.validator.manifest.Manifest;
+import uk.ac.ebi.ena.webin.cli.validator.manifest.SequenceManifest;
 import uk.ac.ebi.ena.webin.cli.validator.reference.Attribute;
 import uk.ac.ebi.ena.webin.cli.validator.reference.Sample;
 import uk.ac.ebi.ena.webin.cli.validator.reference.Study;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -156,6 +162,65 @@ public class SubmissionValidatorTest {
                     break;
                 case UNLOCALISED_LIST:
                     assertEquals(f.getReportFile().getAbsolutePath(), new File(unlocalised+".report").getAbsolutePath());
+                    break;
+            }
+        }
+    }
+
+    @Test
+    public void testMapSequenceManifestToSubmissionOptions() throws ValidationEngineException {
+        String flatFile = "/home/abc/flatFile.fl";
+        String tabFile = "/home/abc/tabFile.tsv";
+
+        Manifest manifest = new SequenceManifest();
+        manifest.setName("test_manifest");
+        manifest.setAddress("wellcome genome campus");
+        manifest.setAuthors("Senthil.V");
+        manifest.setReportFile(new File("/home/reports/other_reports.report"));
+        manifest.setProcessDir(new File("/home/process"));
+        manifest.setWebinRestUri("https://wwwdev.ebi.ac.uk/ena/submit/drop-box/");
+        manifest.setBiosamplesUri("https://wwwdev.ebi.ac.uk/biosamples/");
+
+        SubmissionFiles<SequenceManifest.FileType> submissionFiles = new SubmissionFiles<>();
+        submissionFiles.add(new SubmissionFile( SequenceManifest.FileType.FLATFILE, new File(flatFile),new File(flatFile+".report")));
+        submissionFiles.add(new SubmissionFile( SequenceManifest.FileType.TAB, new File(tabFile),  new File(tabFile+".report")));
+        manifest.setFiles(submissionFiles);
+
+        Sample sample = new Sample();
+        sample.setBioSampleId("SAM1234");
+        sample.setOrganism("Homo sapiens");
+        sample.setTaxId(9606);
+        manifest.setSample(sample);
+
+        Study study = new Study();
+        study.setBioProjectId("PRJ1234");
+        study.setLocusTags(Collections.singletonList("SPLJ"));
+        manifest.setStudy(study);
+
+        SubmissionOptions options = new SubmissionValidator().mapManifestToSubmissionOptions(manifest);
+        AssemblyInfoEntry infoEntry = options.assemblyInfoEntry.get();
+        assertEquals("test_manifest", infoEntry.getName());
+        assertEquals("PRJ1234",infoEntry.getStudyId());
+        assertEquals("wellcome genome campus", infoEntry.getAddress());
+        assertEquals("Senthil.V", infoEntry.getAuthors());
+        assertEquals("SAM1234", infoEntry.getBiosampleId());
+        assertEquals("SPLJ", options.locusTagPrefixes.get().get(0));
+        assertEquals(Context.sequence, options.context.get());
+        assertEquals(2, options.submissionFiles.get().getFiles().size());
+        assertEquals(new File("/home/reports").getAbsolutePath(), options.reportDir.get());
+        assertEquals(new File("/home/process").getAbsolutePath(), options.processDir.get());
+        SourceFeature source = options.source.get();
+        assertEquals("9606",source.getSingleQualifier(Qualifier.DB_XREF_QUALIFIER_NAME).getValue());
+        assertEquals("Homo sapiens", source.getScientificName());
+        assertEquals(manifest.getWebinRestUri(), options.webinRestUri.get());
+        assertEquals(manifest.getBiosamplesUri(), options.biosamplesUri.get());
+        for(uk.ac.ebi.embl.api.validation.submission.SubmissionFile f : options.submissionFiles.get().getFiles()){
+            switch(f.getFileType()) {
+                case FLATFILE:
+                    assertEquals(f.getReportFile().getAbsolutePath(), new File(flatFile+".report").getAbsolutePath());
+                    break;
+                case TSV:
+                    assertEquals(f.getReportFile().getAbsolutePath(), new File(tabFile+".report").getAbsolutePath());
                     break;
             }
         }

--- a/src/test/java/uk/ac/ebi/embl/template/TemplateEntryProcessorTest.java
+++ b/src/test/java/uk/ac/ebi/embl/template/TemplateEntryProcessorTest.java
@@ -225,7 +225,6 @@ public class TemplateEntryProcessorTest {
     
     private SubmissionOptions getOptions(){
         SubmissionOptions options=new SubmissionOptions();
-        options.webinCliTestMode=true;
         options.webinAuthToken = Optional.of(getAuthTokenForTest(WEBIN_AUTH_JSON));
         return options;
     }


### PR DESCRIPTION
- updated webin-cli-validator version.
- updated manifest to submission options conversion to use the the new webin rest and biosamples uri fields.