### PR TITLE
ENA-5978: Fixing person name when initials are in the start and end

### DIFF
--- a/src/main/java/uk/ac/ebi/embl/api/validation/helper/ReferenceUtils.java
+++ b/src/main/java/uk/ac/ebi/embl/api/validation/helper/ReferenceUtils.java
@@ -20,7 +20,7 @@ import uk.ac.ebi.embl.api.validation.dao.model.SubmissionAccount;
 import uk.ac.ebi.embl.api.validation.dao.model.SubmissionContact;
 import uk.ac.ebi.embl.api.validation.dao.model.SubmitterReference;
 import uk.ac.ebi.embl.flatfile.FlatFileUtils;
-import uk.ac.ebi.embl.flatfile.reader.embl.EmblPersonMatcher;
+import uk.ac.ebi.embl.flatfile.reader.embl.EmblPersonMatchHelper;
 
 public class ReferenceUtils {
   /**
@@ -64,7 +64,7 @@ public class ReferenceUtils {
     List<Person> authors = new ArrayList<>();
     block = FlatFileUtils.remove(block, ';');
     for (String author : FlatFileUtils.split(block, ",")) {
-      EmblPersonMatcher personMatcher = new EmblPersonMatcher(null);
+      EmblPersonMatchHelper personMatcher = new EmblPersonMatchHelper(null);
       if (!personMatcher.match(author)) {
         authors.add(new ReferenceFactory().createPerson(author, null));
       } else {

--- a/src/main/java/uk/ac/ebi/embl/flatfile/reader/embl/EmblBookMatcher.java
+++ b/src/main/java/uk/ac/ebi/embl/flatfile/reader/embl/EmblBookMatcher.java
@@ -70,11 +70,11 @@ public class EmblBookMatcher extends FlatFileMatcher {
     }
     String editors = getString(GROUP_EDITORS);
     for (String editor : FlatFileUtils.split(editors, ",")) {
-      EmblPersonMatcher emblPersonMatcher = new EmblPersonMatcher(getReader());
-      if (!emblPersonMatcher.match(editor)) {
+      EmblPersonMatchHelper emblPersonMatchHelper = new EmblPersonMatchHelper(getReader());
+      if (!emblPersonMatchHelper.match(editor)) {
         error("RL.15", editor);
       } else {
-        book.addEditor(emblPersonMatcher.getPerson());
+        book.addEditor(emblPersonMatchHelper.getPerson());
       }
     }
     String bookTitle = getString(GROUP_BOOK_TITLE);

--- a/src/main/java/uk/ac/ebi/embl/flatfile/reader/embl/EmblPersonEndInitialMatcher.java
+++ b/src/main/java/uk/ac/ebi/embl/flatfile/reader/embl/EmblPersonEndInitialMatcher.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2019-2024 EMBL - European Bioinformatics Institute
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package uk.ac.ebi.embl.flatfile.reader.embl;
+
+import java.util.regex.Pattern;
+import uk.ac.ebi.embl.api.entry.reference.Person;
+import uk.ac.ebi.embl.api.entry.reference.ReferenceFactory;
+import uk.ac.ebi.embl.flatfile.FlatFileUtils;
+import uk.ac.ebi.embl.flatfile.reader.FlatFileLineReader;
+
+public class EmblPersonEndInitialMatcher extends EmblPersonMatcher {
+
+  private static final int GROUP_NAME = 1;
+  private static final int GROUP_INITIAL = 2;
+
+  public EmblPersonEndInitialMatcher(FlatFileLineReader reader) {
+    super(reader, END_INITIAL_PATTERN);
+  }
+
+  public static final Pattern END_INITIAL_PATTERN =
+      Pattern.compile(
+          "^([^\\.]+)" // Name
+              + "(\\s+[^\\s\\.]*\\s*\\..*)?$"); // Initial
+
+  @Override
+  public Person getPerson() {
+    // GROUP_INITIAL must be mapped in initial
+    String initial = getString(GROUP_INITIAL);
+    if (initial != null) {
+      initial = FlatFileUtils.shrink(initial.trim(), '.');
+    }
+    // GROUP_NAME must be mapped in surname
+    String surame = getString(GROUP_NAME);
+    if (surame != null) {
+      surame = FlatFileUtils.shrink(surame.trim(), '.');
+    }
+    return (new ReferenceFactory()).createPerson(surame, initial);
+  }
+}

--- a/src/main/java/uk/ac/ebi/embl/flatfile/reader/embl/EmblPersonMatchHelper.java
+++ b/src/main/java/uk/ac/ebi/embl/flatfile/reader/embl/EmblPersonMatchHelper.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2019-2024 EMBL - European Bioinformatics Institute
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package uk.ac.ebi.embl.flatfile.reader.embl;
+
+import uk.ac.ebi.embl.api.entry.reference.Person;
+import uk.ac.ebi.embl.flatfile.reader.FlatFileLineReader;
+
+public class EmblPersonMatchHelper {
+
+  FlatFileLineReader reader;
+
+  public EmblPersonMatchHelper(FlatFileLineReader reader) {
+    this.reader = reader;
+  }
+
+  private EmblPersonMatcher personMatcher;
+
+  public Person getPerson() {
+    return personMatcher.getPerson();
+  }
+
+  public boolean match(String string) {
+    EmblPersonMatcher startInitialPersonMatcher = new EmblPersonStartInitialMatcher(reader);
+    EmblPersonMatcher endInitialPersonMatcher = new EmblPersonEndInitialMatcher(reader);
+
+    if (!startInitialPersonMatcher.match(string)) {
+      if (endInitialPersonMatcher.match(string)) {
+        personMatcher = endInitialPersonMatcher;
+        return true;
+      }
+    } else {
+      personMatcher = startInitialPersonMatcher;
+      return true;
+    }
+    return false;
+  }
+}

--- a/src/main/java/uk/ac/ebi/embl/flatfile/reader/embl/EmblPersonMatchHelper.java
+++ b/src/main/java/uk/ac/ebi/embl/flatfile/reader/embl/EmblPersonMatchHelper.java
@@ -10,6 +10,8 @@
  */
 package uk.ac.ebi.embl.flatfile.reader.embl;
 
+import com.google.common.base.Objects;
+import org.apache.commons.lang.ObjectUtils;
 import uk.ac.ebi.embl.api.entry.reference.Person;
 import uk.ac.ebi.embl.flatfile.reader.FlatFileLineReader;
 
@@ -31,15 +33,12 @@ public class EmblPersonMatchHelper {
     EmblPersonMatcher startInitialPersonMatcher = new EmblPersonStartInitialMatcher(reader);
     EmblPersonMatcher endInitialPersonMatcher = new EmblPersonEndInitialMatcher(reader);
 
-    if (!startInitialPersonMatcher.match(string)) {
-      if (endInitialPersonMatcher.match(string)) {
-        personMatcher = endInitialPersonMatcher;
-        return true;
-      }
-    } else {
+    if (endInitialPersonMatcher.match(string)){
+      personMatcher = endInitialPersonMatcher;
+    }else if (startInitialPersonMatcher.match(string)){
       personMatcher = startInitialPersonMatcher;
-      return true;
     }
-    return false;
+
+    return personMatcher!=null;
   }
 }

--- a/src/main/java/uk/ac/ebi/embl/flatfile/reader/embl/EmblPersonMatcher.java
+++ b/src/main/java/uk/ac/ebi/embl/flatfile/reader/embl/EmblPersonMatcher.java
@@ -12,35 +12,14 @@ package uk.ac.ebi.embl.flatfile.reader.embl;
 
 import java.util.regex.Pattern;
 import uk.ac.ebi.embl.api.entry.reference.Person;
-import uk.ac.ebi.embl.api.entry.reference.ReferenceFactory;
-import uk.ac.ebi.embl.flatfile.FlatFileUtils;
 import uk.ac.ebi.embl.flatfile.reader.FlatFileLineReader;
 import uk.ac.ebi.embl.flatfile.reader.FlatFileMatcher;
 
-public class EmblPersonMatcher extends FlatFileMatcher {
+public abstract class EmblPersonMatcher extends FlatFileMatcher {
 
-  public EmblPersonMatcher(FlatFileLineReader reader) {
+  public EmblPersonMatcher(FlatFileLineReader reader, Pattern PATTERN) {
     super(reader, PATTERN);
   }
 
-  public static final Pattern PATTERN =
-      Pattern.compile(
-          "^([^\\.]+)"
-              + // surname
-              "(\\s+[^\\s\\.]*\\s*\\..*)?$"); // first name
-
-  private static final int GROUP_SURNAME = 1;
-  private static final int GROUP_FIRST_NAME = 2;
-
-  public Person getPerson() {
-    String surname = getString(GROUP_SURNAME);
-    if (surname != null) {
-      surname = surname.trim();
-    }
-    String firstName = getString(GROUP_FIRST_NAME);
-    if (firstName != null) {
-      firstName = FlatFileUtils.shrink(firstName.trim(), '.');
-    }
-    return (new ReferenceFactory()).createPerson(surname, firstName);
-  }
+  public abstract Person getPerson();
 }

--- a/src/main/java/uk/ac/ebi/embl/flatfile/reader/embl/EmblPersonStartInitialMatcher.java
+++ b/src/main/java/uk/ac/ebi/embl/flatfile/reader/embl/EmblPersonStartInitialMatcher.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2019-2024 EMBL - European Bioinformatics Institute
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package uk.ac.ebi.embl.flatfile.reader.embl;
+
+import java.util.regex.Pattern;
+import uk.ac.ebi.embl.api.entry.reference.Person;
+import uk.ac.ebi.embl.api.entry.reference.ReferenceFactory;
+import uk.ac.ebi.embl.flatfile.FlatFileUtils;
+import uk.ac.ebi.embl.flatfile.reader.FlatFileLineReader;
+
+public class EmblPersonStartInitialMatcher extends EmblPersonMatcher {
+
+  private static final int GROUP_INITIAL = 1;
+  private static final int GROUP_NAME = 2;
+
+  public EmblPersonStartInitialMatcher(FlatFileLineReader reader) {
+    super(reader, START_INITIAL_PATTERN);
+  }
+
+  public static final Pattern START_INITIAL_PATTERN =
+      Pattern.compile(
+          "^((?:[\\w]\\s*\\.\\s*)+)" // Initial
+              + "\\s*"
+              + "([\\w].*)$"); // Name
+
+  @Override
+  public Person getPerson() {
+    // GROUP_INITIAL must be mapped in initial
+    String initial = getString(GROUP_INITIAL);
+    if (initial != null) {
+      initial = FlatFileUtils.shrink(initial.trim(), '.');
+    }
+    // GROUP_NAME must be mapped in surname
+    String surame = getString(GROUP_NAME);
+    if (surame != null) {
+      surame = FlatFileUtils.shrink(surame.trim(), '.');
+    }
+    return (new ReferenceFactory()).createPerson(surame, initial);
+  }
+}

--- a/src/main/java/uk/ac/ebi/embl/flatfile/reader/embl/RAReader.java
+++ b/src/main/java/uk/ac/ebi/embl/flatfile/reader/embl/RAReader.java
@@ -33,7 +33,7 @@ public class RAReader extends MultiLineBlockReader {
     getCache().getReference().setAuthorExists(true);
     block = FlatFileUtils.remove(block, ';');
     for (String author : FlatFileUtils.split(block, ",")) {
-      EmblPersonMatcher personMatcher = new EmblPersonMatcher(this);
+      EmblPersonMatchHelper personMatcher = new EmblPersonMatchHelper(this);
       if (!personMatcher.match(author)) {
         getCache().getPublication().addAuthor(new ReferenceFactory().createPerson(author, null));
       } else {

--- a/src/test/java/uk/ac/ebi/embl/flatfile/reader/embl/RAReaderTest.java
+++ b/src/test/java/uk/ac/ebi/embl/flatfile/reader/embl/RAReaderTest.java
@@ -18,11 +18,11 @@ import uk.ac.ebi.embl.api.validation.ValidationResult;
 public class RAReaderTest extends EmblReaderTest {
 
   public void testRead_Authors1() throws IOException {
-    initLineReader("RA   Puzio P.A., von Blau A., Ebneth M., Cook.A;\n");
+    initLineReader("RA   Puzio P.A., von Blau A., Ebneth M., Cook.A, S.Jonathan, A . Arthur;\n");
     Publication publication = lineReader.getCache().getPublication();
     ValidationResult result = (new RAReader(lineReader)).read(entry);
     assertEquals(0, result.count(Severity.ERROR));
-    assertEquals(4, publication.getAuthors().size());
+    assertEquals(6, publication.getAuthors().size());
     assertEquals("Puzio", publication.getAuthors().get(0).getSurname());
     assertEquals("P.A.", publication.getAuthors().get(0).getFirstName());
     assertEquals("von Blau", publication.getAuthors().get(1).getSurname());
@@ -31,16 +31,21 @@ public class RAReaderTest extends EmblReaderTest {
     assertEquals("M.", publication.getAuthors().get(2).getFirstName());
     assertNull(publication.getAuthors().get(3).getFirstName());
     assertEquals("Cook.A", publication.getAuthors().get(3).getSurname());
+    assertEquals("Jonathan", publication.getAuthors().get(4).getSurname());
+    assertEquals("S.", publication.getAuthors().get(4).getFirstName());
+    assertEquals("Arthur", publication.getAuthors().get(5).getSurname());
+    assertEquals("A .", publication.getAuthors().get(5).getFirstName());
   }
 
   public void testRead_Authors2() throws IOException {
     initLineReader(
         "RA   Antonellis ;A.,; Ayele, Ben;jamin B.. C. D., Blakesley, Boakye A.,\n"
-            + "RA   Bouffard G.G., Brinkley C.,, ,, , ,, ,, ; Brooks S., Chu G., Coleman H., Engle J.,\n");
+            + "RA   Bouffard G.G., Brinkley C.,, ,, , ,, ,, ; Brooks S., Chu G., Coleman H., Engle J.,\n"
+            + "RA   S.Jonathan, A . Arthur\n");
     Publication publication = lineReader.getCache().getPublication();
     ValidationResult result = (new RAReader(lineReader)).read(entry);
     assertEquals(0, result.count(Severity.ERROR));
-    assertEquals(11, publication.getAuthors().size());
+    assertEquals(13, publication.getAuthors().size());
     assertEquals("Antonellis", publication.getAuthors().get(0).getSurname());
     assertEquals("A.", publication.getAuthors().get(0).getFirstName());
     assertEquals("Ayele", publication.getAuthors().get(1).getSurname());
@@ -63,17 +68,11 @@ public class RAReaderTest extends EmblReaderTest {
     assertEquals("H.", publication.getAuthors().get(9).getFirstName());
     assertEquals("Engle", publication.getAuthors().get(10).getSurname());
     assertEquals("J.", publication.getAuthors().get(10).getFirstName());
+    assertEquals("Jonathan", publication.getAuthors().get(11).getSurname());
+    assertEquals("S.", publication.getAuthors().get(11).getFirstName());
+    assertEquals("Arthur", publication.getAuthors().get(12).getSurname());
+    assertEquals("A .", publication.getAuthors().get(12).getFirstName());
   }
-
-  /*	public void testRead_InvalidAuthors() throws IOException {
-  	initLineReader(
-     		"RA   A. B. C.\n"
-  	);
-  	Publication publication = lineReader.getCache().getPublication();
-  	ValidationResult result = (new RAReader(lineReader)).read(entry);
-  	assertEquals(1, result.count("RA.1", Severity.ERROR));
-  	assertEquals(0, publication.getAuthors().size());
-  }*/
 
   public void testRead_NoAuthors() throws IOException {
     initLineReader("RA\n");

--- a/src/test/java/uk/ac/ebi/embl/flatfile/reader/embl/RAReaderTest.java
+++ b/src/test/java/uk/ac/ebi/embl/flatfile/reader/embl/RAReaderTest.java
@@ -18,7 +18,7 @@ import uk.ac.ebi.embl.api.validation.ValidationResult;
 public class RAReaderTest extends EmblReaderTest {
 
   public void testRead_Authors1() throws IOException {
-    initLineReader("RA   Puzio P.A., von Blau A., Ebneth M., Cook.A, S.Jonathan, A . Arthur;\n");
+    initLineReader("RA   Puzio P.A., von Blau A., Ebneth M., Cook.A, S.Jonathan, A. Arthur;\n");
     Publication publication = lineReader.getCache().getPublication();
     ValidationResult result = (new RAReader(lineReader)).read(entry);
     assertEquals(0, result.count(Severity.ERROR));
@@ -34,14 +34,14 @@ public class RAReaderTest extends EmblReaderTest {
     assertEquals("Jonathan", publication.getAuthors().get(4).getSurname());
     assertEquals("S.", publication.getAuthors().get(4).getFirstName());
     assertEquals("Arthur", publication.getAuthors().get(5).getSurname());
-    assertEquals("A .", publication.getAuthors().get(5).getFirstName());
+    assertEquals("A.", publication.getAuthors().get(5).getFirstName());
   }
 
   public void testRead_Authors2() throws IOException {
     initLineReader(
         "RA   Antonellis ;A.,; Ayele, Ben;jamin B.. C. D., Blakesley, Boakye A.,\n"
             + "RA   Bouffard G.G., Brinkley C.,, ,, , ,, ,, ; Brooks S., Chu G., Coleman H., Engle J.,\n"
-            + "RA   S.Jonathan, A . Arthur\n");
+            + "RA   S.Jonathan, A. Arthur\n");
     Publication publication = lineReader.getCache().getPublication();
     ValidationResult result = (new RAReader(lineReader)).read(entry);
     assertEquals(0, result.count(Severity.ERROR));
@@ -71,7 +71,7 @@ public class RAReaderTest extends EmblReaderTest {
     assertEquals("Jonathan", publication.getAuthors().get(11).getSurname());
     assertEquals("S.", publication.getAuthors().get(11).getFirstName());
     assertEquals("Arthur", publication.getAuthors().get(12).getSurname());
-    assertEquals("A .", publication.getAuthors().get(12).getFirstName());
+    assertEquals("A.", publication.getAuthors().get(12).getFirstName());
   }
 
   public void testRead_NoAuthors() throws IOException {


### PR DESCRIPTION
Added three new classes:
- EmblPersonMatchHelper
- EmblPersonEndInitialMatcher
- EmblPersonStartInitialMatcher

Added a helper class EmblPersonMatchHelper is used to decide if we need to use either  EmblPersonEndInitialMatcher or EmblPersonStartInitialMatcher

