### PR TITLE
ENA-6164: Removing the complement check in CdsTranslator as the compl…

### DIFF
--- a/src/main/java/uk/ac/ebi/embl/api/translation/CdsTranslator.java
+++ b/src/main/java/uk/ac/ebi/embl/api/translation/CdsTranslator.java
@@ -423,16 +423,8 @@ public class CdsTranslator {
 
     CompoundLocation compoundLocation = feature.getLocations();
 
-    // Note that if the compound location is a global complement
-    // then the left and right partiality are reversed between CdsFeature
-    // and Translator.
-    if (compoundLocation.isComplement()) {
-      translator.setFivePrimePartial(compoundLocation.isThreePrimePartial());
-      translator.setThreePrimePartial(compoundLocation.isFivePrimePartial());
-    } else {
-      translator.setFivePrimePartial(compoundLocation.isFivePrimePartial());
-      translator.setThreePrimePartial(compoundLocation.isThreePrimePartial());
-    }
+    translator.setFivePrimePartial(compoundLocation.isFivePrimePartial());
+    translator.setThreePrimePartial(compoundLocation.isThreePrimePartial());
 
     // Set a pseudo translation.
     translator.setNonTranslating(feature.isPseudo());

--- a/src/test/java/uk/ac/ebi/embl/api/translation/CdsTranslatorTest.java
+++ b/src/test/java/uk/ac/ebi/embl/api/translation/CdsTranslatorTest.java
@@ -880,21 +880,21 @@ public class CdsTranslatorTest {
     cdsFeature.setTranslationTable(11);
     cdsFeature.getLocations().setComplement(true);
     cdsFeature.getLocations().addLocation(locationFactory.createLocalRange(1L, 6L, false));
-    cdsFeature.getLocations().setFivePrimePartial(true);
+    cdsFeature.getLocations().setThreePrimePartial(true);
     String translation = "M";
-    assertTrue(cdsFeature.getLocations().isFivePrimePartial());
-    assertFalse(cdsFeature.getLocations().isThreePrimePartial());
+    assertFalse(cdsFeature.getLocations().isFivePrimePartial());
+    assertTrue(cdsFeature.getLocations().isThreePrimePartial());
     assertFalse(testValidTranslation(translation, "Translator-14"));
     assertEquals(
-        "complement(1..>6)",
+        "complement(<1..6)",
         FeatureLocationWriter.renderCompoundLocation(cdsFeature.getLocations()));
-    assertTrue(cdsFeature.getLocations().isFivePrimePartial());
-    assertFalse(cdsFeature.getLocations().isThreePrimePartial());
+    assertFalse(cdsFeature.getLocations().isFivePrimePartial());
+    assertTrue(cdsFeature.getLocations().isThreePrimePartial());
     assertTrue(testValidTranslationFixMode(translation, "fixValidStopCodonRemove3Partial"));
-    assertTrue(cdsFeature.getLocations().isFivePrimePartial());
+    assertFalse(cdsFeature.getLocations().isFivePrimePartial());
     assertFalse(cdsFeature.getLocations().isThreePrimePartial());
     assertEquals(
-        "complement(1..>6)",
+        "complement(1..6)",
         FeatureLocationWriter.renderCompoundLocation(cdsFeature.getLocations()));
   }
 


### PR DESCRIPTION
ENA-6164: Removing the complement check in CdsTranslator as the complement consideration is done in isThreePrime and isFivePrime methods