### PR TITLE
ENA-6061: Change for allowing geo_loc_name

### DIFF
--- a/src/main/java/uk/ac/ebi/embl/api/entry/qualifier/Qualifier.java
+++ b/src/main/java/uk/ac/ebi/embl/api/entry/qualifier/Qualifier.java
@@ -87,7 +87,7 @@ public class Qualifier implements HasOrigin, Serializable, Comparable<Qualifier>
   public static final String HOST_QUALIFIER_NAME = "host";
   public static final String OPERON_QUALIFIER_NAME = "operon";
   public static final String COUNTRY_QUALIFIER_NAME = "country";
-  public static final String GEO_LOCATION_NAME_QUALIFIER = "geo_loc_name";
+  public static final String GEO_LOCATION_QUALIFIER_NAME = "geo_loc_name";
   public static final String REGULATORY_CLASS_QUALIFIER_NAME = "regulatory_class";
   public static final String ALTITUDE_QUALIFIER_NAME = "altitude";
   public static final String ARTIFICIAL_LOCATION = "artificial_location";

--- a/src/main/java/uk/ac/ebi/embl/api/entry/qualifier/Qualifier.java
+++ b/src/main/java/uk/ac/ebi/embl/api/entry/qualifier/Qualifier.java
@@ -87,6 +87,7 @@ public class Qualifier implements HasOrigin, Serializable, Comparable<Qualifier>
   public static final String HOST_QUALIFIER_NAME = "host";
   public static final String OPERON_QUALIFIER_NAME = "operon";
   public static final String COUNTRY_QUALIFIER_NAME = "country";
+  public static final String GEO_LOCATION_NAME = "geo_loc_name";
   public static final String REGULATORY_CLASS_QUALIFIER_NAME = "regulatory_class";
   public static final String ALTITUDE_QUALIFIER_NAME = "altitude";
   public static final String ARTIFICIAL_LOCATION = "artificial_location";

--- a/src/main/java/uk/ac/ebi/embl/api/entry/qualifier/Qualifier.java
+++ b/src/main/java/uk/ac/ebi/embl/api/entry/qualifier/Qualifier.java
@@ -87,7 +87,7 @@ public class Qualifier implements HasOrigin, Serializable, Comparable<Qualifier>
   public static final String HOST_QUALIFIER_NAME = "host";
   public static final String OPERON_QUALIFIER_NAME = "operon";
   public static final String COUNTRY_QUALIFIER_NAME = "country";
-  public static final String GEO_LOCATION_NAME = "geo_loc_name";
+  public static final String GEO_LOCATION_NAME_QUALIFIER = "geo_loc_name";
   public static final String REGULATORY_CLASS_QUALIFIER_NAME = "regulatory_class";
   public static final String ALTITUDE_QUALIFIER_NAME = "altitude";
   public static final String ARTIFICIAL_LOCATION = "artificial_location";

--- a/src/main/java/uk/ac/ebi/embl/api/validation/plan/ValidationUnit.java
+++ b/src/main/java/uk/ac/ebi/embl/api/validation/plan/ValidationUnit.java
@@ -61,10 +61,10 @@ public enum ValidationUnit {
       StrainQualifierValueFix.class,
       Lat_lonValueFix.class,
       QualifierValueFix.class,
+      FeatureQualifierRenameFix.class,
       CountryQualifierFix.class,
       MoleculeTypeAndQualifierFix.class,
       ExclusiveQualifierTransformToNoteQualifierFix.class,
-      FeatureQualifierRenameFix.class,
       TaxonomicDivisionNotQualifierFix.class,
       // ENA-6041: Removing the fix as created issue in putff.
       // This fix can be totally removed if there is no use of it

--- a/src/main/resources/uk/ac/ebi/embl/api/validation/data/feature-qualifier-rename.tsv
+++ b/src/main/resources/uk/ac/ebi/embl/api/validation/data/feature-qualifier-rename.tsv
@@ -2,3 +2,4 @@
 
 mobile_element	mobile_element_type
 label	note
+geo_loc_name	country

--- a/src/test/java/uk/ac/ebi/embl/api/validation/fixer/feature/FeatureQualifierRenameFixTest.java
+++ b/src/test/java/uk/ac/ebi/embl/api/validation/fixer/feature/FeatureQualifierRenameFixTest.java
@@ -87,7 +87,7 @@ public class FeatureQualifierRenameFixTest {
 
   @Test
   public void testCheck_geo_loc_name_QualifierName() {
-    feature.setSingleQualifier(Qualifier.GEO_LOCATION_NAME);
+    feature.setSingleQualifier(Qualifier.GEO_LOCATION_NAME_QUALIFIER);
     ValidationResult validationResult = check.check(feature);
     assertEquals(1, validationResult.count("FeatureQualifierRenameFix", Severity.FIX));
   }

--- a/src/test/java/uk/ac/ebi/embl/api/validation/fixer/feature/FeatureQualifierRenameFixTest.java
+++ b/src/test/java/uk/ac/ebi/embl/api/validation/fixer/feature/FeatureQualifierRenameFixTest.java
@@ -87,7 +87,7 @@ public class FeatureQualifierRenameFixTest {
 
   @Test
   public void testCheck_geo_loc_name_QualifierName() {
-    feature.setSingleQualifier(Qualifier.GEO_LOCATION_NAME_QUALIFIER);
+    feature.setSingleQualifier(Qualifier.GEO_LOCATION_QUALIFIER_NAME);
     ValidationResult validationResult = check.check(feature);
     assertEquals(1, validationResult.count("FeatureQualifierRenameFix", Severity.FIX));
   }

--- a/src/test/java/uk/ac/ebi/embl/api/validation/fixer/feature/FeatureQualifierRenameFixTest.java
+++ b/src/test/java/uk/ac/ebi/embl/api/validation/fixer/feature/FeatureQualifierRenameFixTest.java
@@ -38,9 +38,10 @@ public class FeatureQualifierRenameFixTest {
     DataRow dataRow1 = new DataRow("organism", "qualifier1");
     DataRow dataRow2 = new DataRow("strain", "qualifier2");
     DataRow dataRow3 = new DataRow("label", "note");
+    DataRow dataRow4 = new DataRow("geo_loc_name", "country");
 
     GlobalDataSets.addTestDataSet(
-        GlobalDataSetFile.FEATURE_QUALIFIER_RENAME, dataRow1, dataRow2, dataRow3);
+        GlobalDataSetFile.FEATURE_QUALIFIER_RENAME, dataRow1, dataRow2, dataRow3,dataRow4);
     check = new FeatureQualifierRenameFix();
   }
 
@@ -80,6 +81,13 @@ public class FeatureQualifierRenameFixTest {
   public void testCheck_labelQualifierName() {
 
     feature.setSingleQualifier(Qualifier.LABEL_QUALIFIER_NAME);
+    ValidationResult validationResult = check.check(feature);
+    assertEquals(1, validationResult.count("FeatureQualifierRenameFix", Severity.FIX));
+  }
+
+  @Test
+  public void testCheck_geo_loc_name_QualifierName() {
+    feature.setSingleQualifier(Qualifier.GEO_LOCATION_NAME);
     ValidationResult validationResult = check.check(feature);
     assertEquals(1, validationResult.count("FeatureQualifierRenameFix", Severity.FIX));
   }


### PR DESCRIPTION
- Adding an entry for geo_loc_name in feature-qualifier-rename.tsv
- Moving FeatureQualifierRenameFix before CountryQualifierFix in Validation unit