### PR TITLE
Ttena 245 topology lowercase fix

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,7 +10,7 @@ image: openjdk:17.0.2-slim-bullseye
 # isolated from any previous builds.
 variables:
   APP_NAME: 'sequencetools'
-  APP_VERSION: "2.35.1"
+  APP_VERSION: "2.35.2"
   GRADLE_OPTS: "-Dorg.gradle.daemon=false -Dorg.gradle.jvmargs=-Xmx3g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8"
 
 stages:

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,6 @@ repositories {
     mavenCentral()
     maven {
         url "https://gitlab.ebi.ac.uk/api/v4/groups/enasequence/-/packages/maven"
-
         credentials(HttpHeaderCredentials) {
             name = gitlabHeaderName
             value = gitlabHeaderValue

--- a/src/main/java/uk/ac/ebi/embl/fasta/writer/FastaFileWriter.java
+++ b/src/main/java/uk/ac/ebi/embl/fasta/writer/FastaFileWriter.java
@@ -120,7 +120,7 @@ public class FastaFileWriter {
         json.put("molecule_type", entry.getSequence().getMoleculeType());
       }
       if (entry.getSequence().getTopology() != null) {
-        json.put("topology", entry.getSequence().getTopology().toString());
+        json.put("topology", entry.getSequence().getTopology().toString().toLowerCase());
       }
     }
 

--- a/src/test/java/uk/ac/ebi/embl/fasta/writer/FastaFileWriterTest.java
+++ b/src/test/java/uk/ac/ebi/embl/fasta/writer/FastaFileWriterTest.java
@@ -93,7 +93,7 @@ public class FastaFileWriterTest {
 
     // assert
     String output =
-        ">ad0897987.3 | {\"description\":\"hihi\",\"molecule_type\":\"genomicDNA\",\"topology\":\"LINEAR\"}\nAAA\n";
+        ">ad0897987.3 | {\"description\":\"hihi\",\"molecule_type\":\"genomicDNA\",\"topology\":\"linear\"}\nAAA\n";
     String actualOutput = writer.toString();
     assertEquals(output, actualOutput);
   }


### PR DESCRIPTION
Forced for the TSV->FASTA writer to write out topology in lowercase, as right now it was outputted in uppercase because of the Topology ENUM definition. The flatfiles themselves have topology in lowercase, so following that convention